### PR TITLE
Update send-and-transfer.sol

### DIFF
--- a/send-and-transfer.sol
+++ b/send-and-transfer.sol
@@ -36,7 +36,6 @@ contract HelloWorld{
 
     function createPerson(string memory name, uint age, uint height) public payable costs(1 ether){
       require(age < 150, "Age needs to be below 150");
-      require(msg.value >= 1 ether);
       balance += msg.value;
 
         //This creates a person
@@ -96,9 +95,9 @@ contract HelloWorld{
        return creators[index];
    }
    function withdrawAll() public onlyOwner returns(uint) {
-       toTransfer = balance;
+       uint toTransfer = balance;
        balance = 0;
-       msg.sender.transfer(balance);
+       msg.sender.transfer(toTransfer);
        return toTransfer;
    }
 


### PR DESCRIPTION
I removed this piece of code from line 39.

  require(msg.value >= 1 ether);
It does not necessary in the code, because we defined the costs modifier in line 25-26.

-This bug was discovered by Jon_m -

Bug fix:

line98: uint toTransfer = balance; → It was missing the uint command.
line100: msg.sender.transfer(toTransfer); → Like you mentioned before, this is how it is supposed to be
The code is failing in the original case, if you try to withdraw all your funds from the contract. That is gonna wipe itself and that is not gonna return for the contract owner. In the previous line we defined balance = 0;, after there is no funds to send to the owner.